### PR TITLE
make instructions more userproof

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ python3
 ```
 git clone https://github.com/tomlinsonk/site-graph.git
 cd site-graph
+pip3 install -r requirements.txt
 python3 site_graph.py https://www.cs.cornell.edu/~kt/
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,15 @@ python3
 - scipy
 
 ## Running
-Replacing my URL with yours, run:
-```python3 site_graph.py https://www.cs.cornell.edu/~kt/```
+
+```
+git clone https://github.com/tomlinsonk/site-graph.git
+cd site-graph
+python3 site_graph.py https://www.cs.cornell.edu/~kt/
+```
+
+To see site of interest for you, just change the URL.
+
 To see more options, run:
 ```python3 site_graph.py -h```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+beautifulsoup4
+pyvis
+networkx
+argparse
+scipy
+numpy


### PR DESCRIPTION
ready for copy paste, less confusing for newbies
(some time ago I would be stumped by this)

It is kind of taste issue, but I value copy-pastable basic instruction highly.

This way I can immediately check whether repository passes basic test (and I have run in past into cases where own repo instructions triggered bugs)